### PR TITLE
Fix typo in comment for simple_agent.py

### DIFF
--- a/agents/simple_agent.py
+++ b/agents/simple_agent.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Random Agent."""
+"""Simple Agent."""
 
 from rl_env import Agent
 


### PR DESCRIPTION
Just correcting a single typo, the heading was intended to be "Simple Agent."