### PR TITLE
Fix/correct spelling errors

### DIFF
--- a/pyhanabi.py
+++ b/pyhanabi.py
@@ -749,7 +749,7 @@ class HanabiGame(object):
 
     The number of cards in a player's hand may be smaller than this maximum
     a) at the beginning of the game before cards are dealt out, b) after
-    ane Play or Discard action and before the subsequent deal event, and c)
+    any Play or Discard action and before the subsequent deal event, and c)
     after the deck is empty and cards can no longer be dealt to a player.
     """
     return lib.HandSize(self._game)

--- a/rl_env.py
+++ b/rl_env.py
@@ -27,7 +27,7 @@ MOVE_TYPES = [_.name for _ in pyhanabi.HanabiMoveType]
 
 
 class Environment(object):
-  """Abtract Environment interface.
+  """Abstract Environment interface.
 
   All concrete implementations of an environment should derive from this
   interface and implement the method stubs.


### PR DESCRIPTION
## Pull Request (PR) Overview:
While reading though the ```rl_env.py``` and ```pyhanabi.py``` scripts I noticed two small _typos_. This PR attempts  to correct these small _typos_.

## Changes made
* Fix incorrect spelling of abstract (see ef74ee3fd46df73b1ec62e485a5aa4b73861fba7)
* Fix incorrect spelling of 'any' (see add3da89f34f7b8656f61904244296d243e94553)

