### PR TITLE
Fix HanabiState.copy setting a bad pointer for _game member

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.pyc
+Makefile
+CMakeFiles/
+CMakeCache.txt
+*.cmake

--- a/hanabi_learning_environment/pyhanabi.cc
+++ b/hanabi_learning_environment/pyhanabi.cc
@@ -311,12 +311,13 @@ void DeleteState(pyhanabi_state_t* state) {
   state->state = nullptr;
 }
 
-const void* StateParentGame(pyhanabi_state_t* state) {
+void StateParentGame(pyhanabi_state_t* state, pyhanabi_game_t* game) {
   REQUIRE(state != nullptr);
   REQUIRE(state->state != nullptr);
-  return static_cast<const void*>(
-      reinterpret_cast<hanabi_learning_env::HanabiState*>(state->state)
-          ->ParentGame());
+  REQUIRE(game != nullptr);
+  auto hanabi_state =
+      reinterpret_cast<hanabi_learning_env::HanabiState*>(state->state); 
+  game->game = (void*)hanabi_state->ParentGame();
 }
 
 void StateApplyMove(pyhanabi_state_t* state, pyhanabi_move_t* move) {

--- a/hanabi_learning_environment/pyhanabi.h
+++ b/hanabi_learning_environment/pyhanabi.h
@@ -111,7 +111,7 @@ int HistoryItemDealToPlayer(pyhanabi_history_item_t* item);
 void NewState(pyhanabi_game_t* game, pyhanabi_state_t* state);
 void CopyState(const pyhanabi_state_t* src, pyhanabi_state_t* dest);
 void DeleteState(pyhanabi_state_t* state);
-const void* StateParentGame(pyhanabi_state_t* state);
+void StateParentGame(pyhanabi_state_t* state, pyhanabi_game_t* game);
 void StateApplyMove(pyhanabi_state_t* state, pyhanabi_move_t* move);
 int StateCurPlayer(pyhanabi_state_t* state);
 void StateDealRandomCard(pyhanabi_state_t* state);

--- a/hanabi_learning_environment/pyhanabi.py
+++ b/hanabi_learning_environment/pyhanabi.py
@@ -68,7 +68,7 @@ def try_cdef(header=PYHANABI_HEADER, prefixes=DEFAULT_CDEF_PREFIXES):
           cdef_string = cdef_string + line + "\n"
       ffi.cdef(cdef_string)
       cdef_loaded_flag = True
-      return True
+      return True 
     except IOError:
       pass
   return False
@@ -516,7 +516,8 @@ class HanabiState(object):
       self._game = game.c_game
       lib.NewState(self._game, self._state)
     else:
-      self._game = lib.StateParentGame(c_state)
+      self._game = ffi.new("pyhanabi_game_t*")
+      lib.StateParentGame(c_state, self._game)
       lib.CopyState(c_state, self._state)
 
   def copy(self):


### PR DESCRIPTION
Fixes `HanabiState.fireworks()` returning incorrect data when called on a copied HanabiState object.

Came across this bug in work-related project.
The bug is pretty easily fixed by retrieving the parent game of the state into an existing `pyhanabi_game_t*` instead of returning a void pointer as was done before.

Steps to reproduce the bug as it existed:
- Create a `HanabiState` object by calling `HanabiState.copy` or using the copy constructor manually
- `HanabiState._game` will receive a `hanabi_learning_env::HanabiGame*` rather than `pyhanabi_game_t*`.
- `HanabiState.fireworks()` and any derived `HanabiObservation.fireworks()` calls will return bad data, because `lib.NumPlayers`/`lib.NumColors`/`lib.NumRanks` will access garbage memory when called on the resulting `_game` field.