### PR TITLE
Feature: change the hands of players

### DIFF
--- a/hanabi_learning_environment/hanabi_lib/hanabi_hand.cc
+++ b/hanabi_learning_environment/hanabi_lib/hanabi_hand.cc
@@ -84,6 +84,11 @@ void HanabiHand::AddCard(HanabiCard card,
   card_knowledge_.push_back(initial_knowledge);
 }
 
+void HanabiHand::InsertCard(HanabiCard card, int card_index) {
+  REQUIRE(card.IsValid());
+  cards_.insert(cards_.begin() + card_index,card);
+}
+
 void HanabiHand::RemoveFromHand(int card_index,
                                 std::vector<HanabiCard>* discard_pile) {
   if (discard_pile != nullptr) {
@@ -91,6 +96,11 @@ void HanabiHand::RemoveFromHand(int card_index,
   }
   cards_.erase(cards_.begin() + card_index);
   card_knowledge_.erase(card_knowledge_.begin() + card_index);
+}
+
+void HanabiHand::ReturnFromHand(int card_index) {
+  // Adding to deck is handled by ApplyMove in hanabi_state
+  cards_.erase(cards_.begin() + card_index);
 }
 
 uint8_t HanabiHand::RevealColor(const int color) {

--- a/hanabi_learning_environment/hanabi_lib/hanabi_hand.h
+++ b/hanabi_learning_environment/hanabi_lib/hanabi_hand.h
@@ -102,9 +102,13 @@ class HanabiHand {
     return card_knowledge_;
   }
   void AddCard(HanabiCard card, const CardKnowledge& initial_knowledge);
+  // Insert the specified card while maintaining knowledge about the card
+  void InsertCard(HanabiCard card, int card_index);
   // Remove card_index card from hand. Put in discard_pile if not nullptr
   // (pushes the card to the back of the discard_pile vector).
   void RemoveFromHand(int card_index, std::vector<HanabiCard>* discard_pile);
+  // Remove card_index card from hand and put it back into the deck.
+  void ReturnFromHand(int card_index);
   // Make cards with the given rank visible.
   // Returns new information bitmask, bit_i set if card_i color was revealed
   // and was previously unknown.

--- a/hanabi_learning_environment/hanabi_lib/hanabi_move.cc
+++ b/hanabi_learning_environment/hanabi_lib/hanabi_move.cc
@@ -32,8 +32,12 @@ bool HanabiMove::operator==(const HanabiMove& other_move) const {
     case kRevealRank:
       return TargetOffset() == other_move.TargetOffset() &&
              Rank() == other_move.Rank();
+    case kDealSpecific:
     case kDeal:
       return Color() == other_move.Color() && Rank() == other_move.Rank();
+    case kReturn:
+      return CardIndex() == other_move.CardIndex() &&
+             TargetOffset() == other_move.TargetOffset();
     default:
       return true;
   }
@@ -58,6 +62,16 @@ std::string HanabiMove::ToString() const {
       } else {
         return std::string("(Deal XX)");
       }
+    case kDealSpecific:
+      if (color_ >= 0) {
+        return std::string("(Deal ") + ColorIndexToChar(Color()) +
+               RankIndexToChar(Rank()) + ")";
+      } else {
+        return std::string("(Deal XX)");
+      }
+      case kReturn:
+      return "(Return " +  std::to_string(CardIndex()) + "from Player " +
+             std::to_string(TargetOffset()) + ")";
     default:
       return "(INVALID)";
   }

--- a/hanabi_learning_environment/hanabi_lib/hanabi_move.h
+++ b/hanabi_learning_environment/hanabi_lib/hanabi_move.h
@@ -31,7 +31,7 @@ namespace hanabi_learning_env {
 class HanabiMove {
   // HanabiMove is small, and intended to be passed by value.
  public:
-  enum Type { kInvalid, kPlay, kDiscard, kRevealColor, kRevealRank, kDeal };
+  enum Type { kInvalid, kPlay, kDiscard, kRevealColor, kRevealRank, kDeal, kReturn, kDealSpecific};
 
   HanabiMove(Type move_type, int8_t card_index, int8_t target_offset,
              int8_t color, int8_t rank)

--- a/hanabi_learning_environment/hanabi_lib/hanabi_state.cc
+++ b/hanabi_learning_environment/hanabi_lib/hanabi_state.cc
@@ -87,6 +87,12 @@ HanabiCard HanabiState::HanabiDeck::DealCard(int color, int rank) {
   return HanabiCard(IndexToColor(index), IndexToRank(index));
 }
 
+void HanabiState::HanabiDeck::ReturnCard(int color, int rank) {
+  int index = CardToIndex(color, rank);
+  ++card_count_[index];
+  ++total_count_;
+}
+
 HanabiState::HanabiState(const HanabiGame* parent_game, int start_player)
     : parent_game_(parent_game),
       deck_(*parent_game),
@@ -165,6 +171,7 @@ int HanabiState::PlayerToDeal() const {
 
 bool HanabiState::MoveIsLegal(HanabiMove move) const {
   switch (move.MoveType()) {
+    case HanabiMove::kDealSpecific:
     case HanabiMove::kDeal:
       if (cur_player_ != kChancePlayerId) {
         return false;
@@ -212,6 +219,11 @@ bool HanabiState::MoveIsLegal(HanabiMove move) const {
       }
       break;
     }
+    case HanabiMove::kReturn:
+      if (move.CardIndex() >= hands_[move.TargetOffset()].Cards().size()) {
+        return false;
+      }
+      break;
     default:
       return false;
   }
@@ -220,7 +232,10 @@ bool HanabiState::MoveIsLegal(HanabiMove move) const {
 
 void HanabiState::ApplyMove(HanabiMove move) {
   REQUIRE(MoveIsLegal(move));
-  if (deck_.Empty()) {
+  // Special moves are virtual moves used to manipulate the game.
+  bool special_move = move.MoveType() == HanabiMove::kDealSpecific ||
+                      move.MoveType() == HanabiMove::kReturn;
+  if (deck_.Empty() && !special_move) {
     --turns_to_play_;
   }
   HanabiHistoryItem history(move);
@@ -239,11 +254,20 @@ void HanabiState::ApplyMove(HanabiMove move) {
             card_knowledge);
       }
       break;
+    case HanabiMove::kDealSpecific:
+      hands_[move.TargetOffset()].InsertCard(
+          deck_.DealCard(move.Color(), move.Rank()), move.CardIndex());
+      break;
     case HanabiMove::kDiscard:
       history.information_token = IncrementInformationTokens();
       history.color = hands_[cur_player_].Cards()[move.CardIndex()].Color();
       history.rank = hands_[cur_player_].Cards()[move.CardIndex()].Rank();
       hands_[cur_player_].RemoveFromHand(move.CardIndex(), &discard_pile_);
+      break;
+    case HanabiMove::kReturn:
+      deck_.ReturnCard(hands_[move.TargetOffset()].Cards()[move.CardIndex()].Color()
+                      ,hands_[move.TargetOffset()].Cards()[move.CardIndex()].Rank());
+      hands_[move.TargetOffset()].ReturnFromHand(move.CardIndex());
       break;
     case HanabiMove::kPlay:
       history.color = hands_[cur_player_].Cards()[move.CardIndex()].Color();
@@ -270,7 +294,9 @@ void HanabiState::ApplyMove(HanabiMove move) {
     default:
       std::abort();  // Should not be possible.
   }
-  move_history_.push_back(history);
+  if(!special_move){
+    move_history_.push_back(history);
+  }
   AdvanceToNextPlayer();
 }
 

--- a/hanabi_learning_environment/hanabi_lib/hanabi_state.h
+++ b/hanabi_learning_environment/hanabi_lib/hanabi_state.h
@@ -35,6 +35,7 @@ class HanabiState {
    public:
     explicit HanabiDeck(const HanabiGame& game);
     // DealCard returns invalid card on failure.
+    void ReturnCard(int color, int rank);
     HanabiCard DealCard(int color, int rank);
     HanabiCard DealCard(std::mt19937* rng);
     int Size() const { return total_count_; }

--- a/hanabi_learning_environment/pyhanabi.cc
+++ b/hanabi_learning_environment/pyhanabi.cc
@@ -165,6 +165,14 @@ int MoveRank(pyhanabi_move_t* move) {
       ->Rank();
 }
 
+bool GetDealSpecificMove(int card_index, int player, int color, int rank,
+                         pyhanabi_move_t* move) {
+  REQUIRE(move != nullptr);
+  move->move = new hanabi_learning_env::HanabiMove(
+      hanabi_learning_env::HanabiMove::kDealSpecific, card_index, player, color, rank);
+  return move->move != nullptr;
+}
+
 bool GetDiscardMove(int card_index, pyhanabi_move_t* move) {
   REQUIRE(move != nullptr);
   move->move = new hanabi_learning_env::HanabiMove(
@@ -176,6 +184,13 @@ bool GetPlayMove(int card_index, pyhanabi_move_t* move) {
   REQUIRE(move != nullptr);
   move->move = new hanabi_learning_env::HanabiMove(
       hanabi_learning_env::HanabiMove::kPlay, card_index, -1, -1, -1);
+  return move->move != nullptr;
+}
+
+bool GetReturnMove(int card_index,int player, pyhanabi_move_t* move) {
+  REQUIRE(move != nullptr);
+  move->move = new hanabi_learning_env::HanabiMove(
+      hanabi_learning_env::HanabiMove::kReturn, card_index, player, -1, -1);
   return move->move != nullptr;
 }
 

--- a/hanabi_learning_environment/pyhanabi.h
+++ b/hanabi_learning_environment/pyhanabi.h
@@ -89,8 +89,11 @@ int CardIndex(pyhanabi_move_t* move);
 int TargetOffset(pyhanabi_move_t* move);
 int MoveColor(pyhanabi_move_t* move);
 int MoveRank(pyhanabi_move_t* move);
+bool GetDealSpecificMove(int card_index, int player, int color, int rank,
+                         pyhanabi_move_t* move);
 bool GetDiscardMove(int card_index, pyhanabi_move_t* move);
 bool GetPlayMove(int card_index, pyhanabi_move_t* move);
+bool GetReturnMove(int card_index, int player, pyhanabi_move_t* move);
 bool GetRevealColorMove(int target_offset, int color, pyhanabi_move_t* move);
 bool GetRevealRankMove(int target_offset, int rank, pyhanabi_move_t* move);
 


### PR DESCRIPTION
Hi !

I have implemented new features:
- to return a card from a hand in a deck
- to deal a specific card to a player
- to change the hands of a player to a new hand

These two new moves are not present in the history, and the knowledge of the hand is unaltered.
This enables with a bit of manipulation to do something close to #30.
For example, one could add to each player the card they want to be played, discard, hinted, by changing their hands accordingly and then acting on these hands.

The return and deal specific moves were inspired from [mcts-hanabi](https://github.com/MBlogs/mcts-hanabi) (under license Apache 2.0), their original implementation was kept for ```hanabi_hand``` and ```hanabi_move```.

